### PR TITLE
Add Freenode domain verification to root folder

### DIFF
--- a/freenode.txt
+++ b/freenode.txt
@@ -1,0 +1,1 @@
+freenode-verify-123n71


### PR DESCRIPTION
This commit adds a file, `freenode.txt`, to the root folder of the
website. This is done to verify ownership of this domain with the
Freenode staff team, in order to complete a project registration for the
Open Source Diversity initiative on Freenode. This will help us register
and take greater control of `#opensourcediversity` and other channels
underneath that namespace.

This file should not be removed unless instructed by Freenode staff
team.