### PR TITLE
Add Telegram to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,7 @@
 				<p class="lead">For more diversity & inclusion in free & open source software communities 😊</p>
 				<p>
 					<a href="https://discourse.opensourcediversity.org/" class="btn btn-primary" target="_blank" rel="noopener"><img src="img/discourse.svg" /> Join our forum!</a>
+					<a href="https://t.me/diversityandinclusioninoss" class="btn btn-primary" target="_blank" rel="noopener">Join us on Telegram!</a>
 				</p>
 			</div>
 		</section>


### PR DESCRIPTION
At the OSSummit, someone asked abut a Slack for D&I in open source. I wanted to recommend the telegram/IRC we have but wasn't quick enough to find it. I propose to promote it along with our forum at the top of our website.

This PR is a quick fix but could be improved by adding an icon for telegram.