### PR TITLE
Fix typo in 'Diversify Open Source Bangalore' on main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,7 +221,7 @@
 				</a>
 				<a class="col-md-4" href="https://diversifyingopensource.github.io" target="_blank" rel="noopener">
 					<img alt="" src="img/projects/diversifyfoss.png" />
-					<h3>Difersify Open Source<br>Bangalore</h3>
+					<h3>Diversify Open Source<br>Bangalore</h3>
 					<p>We help, encourage and celebrate underrepresented people to contribute in open source projects and speak at conferences!</p>
 				</a>
 				<a class="col-md-4" href="http://heartofcode.org" target="_blank" rel="noopener">


### PR DESCRIPTION
I noticed a small typo under the "Spaces" section of the main page.

Originally it said "Difersify Open Source Bangalore" but I think it was supposed to be "Diversify" instead unless this was intentionally misspelled on purpose. 