### PR TITLE
Remove "Le Reset"

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,11 +226,6 @@
 				</a>
 			</div>
 			<div class="row">
-				<a class="col-sm-6 col-md-4 p-4" href="https://lereset.org" target="_blank" rel="noopener">
-					<img alt="lereset Paris image link" title="lereset Paris" src="img/projects/lereset.jpg" />
-					<h3>Le Reset<br>Paris</h3>
-					<p>Le Reset est un espace inclusif de bidouille et d'apprentissage des technologies numériques à Paris.</p>
-				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="http://doubleunion.org" target="_blank" rel="noopener">
 					<img alt="Double Union San Francisco image link" title="Double Union San Francisco" src="img/projects/doubleunion.png" />
 					<h3>Double Union<br>San Francisco</h3>


### PR DESCRIPTION
The hackerspace announced in June it would not reopen in September: https://twitter.com/le_RESET/status/1271428089319432193 

However, the thread say they are going to announce more in a few days, hence the WIP tag. I am not sure how people want to handle deprecation on the index page, but a PR seemed fitting as a way to discuss that.