### PR TITLE
Removing section from the website

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,11 +115,6 @@
 					<h3>First Timers Only</h3>
 					<p>A beginner-friendly outline and guide to help you get started with open source!</p>
 				</a>
-				<a class="col-sm-6 col-md-4 p-4" href="https://yourfirstpr.github.io" target="_blank" rel="noopener">
-					<img alt="Your First Pull Request image link" title="Your First Pull Request" src="img/projects/yourfirstpr.png" />
-					<h3>Your First PR</h3>
-					<p>Helps you get started contributing to Open Source by showcasing great starter issues on GitHub and elsewhere.</p>
-				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://up-for-grabs.net" target="_blank" rel="noopener">
 					<img alt="Up For Grabs image link" title="Up For Grabs" src="img/projects/upforgrabs.png" />
 					<h3>Up For Grabs</h3>


### PR DESCRIPTION
This resolves #115 by removing the "Your First PR" guide from the homepage. This was resolved in a PR by @everly-gif back on June 21, but there were merge conflicts (+ I don't have access to their branch, so this is simpler).

This should be good to go, tested it out locally and it looks great.