### PR TITLE
Fix decorative image alt text in project cards (#176)

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 		<nav class="navbar navbar-expand-lg fixed-top navbar-dark bg-dark">
 			<div class="container">
 				<a class="navbar-brand" href="#">
-					<img alt="White Flower Icon of Open Source Diversity" title="White Flower Icon" src="img/opensourcediversity-icon-white.svg" />
+					<img alt="Open Source Diversity logo" title="White Flower Icon" src="img/opensourcediversity-icon-white.svg" />
 					Open Source Diversity
 				</a>
 				<button class="navbar-toggler first-button" type="button" data-toggle="collapse" data-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
@@ -104,27 +104,27 @@
 			</header>
 			<div class="row">
 				<a class="col-sm-6 col-md-4 p-4" href="https://www.contributor-covenant.org" target="_blank" rel="noopener">
-					<img alt="Contributor Covenant Image Link" title="Contributor Covenant" src="img/projects/contributorcovenant.png" />
+					<img alt="" title="Contributor Covenant" src="img/projects/contributorcovenant.png" />
 					<h3>Contributor Covenant</h3>
 					<p>A Code of Conduct for Open Source Projects.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://www.firsttimersonly.com" target="_blank" rel="noopener">
-					<img alt="First Timers Only image link" title="First-Timers Only" src="img/projects/FTO.JPG" />
+					<img alt="" title="First-Timers Only" src="img/projects/FTO.JPG" />
 					<h3>First Timers Only</h3>
 					<p>A beginner-friendly outline and guide to help you get started with open source!</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://up-for-grabs.net" target="_blank" rel="noopener">
-					<img alt="Up For Grabs image link" title="Up For Grabs" src="img/projects/upforgrabs.png" />
+					<img alt="" title="Up For Grabs" src="img/projects/upforgrabs.png" />
 					<h3>Up For Grabs</h3>
 					<p>A list of projects which have curated tasks specifically for new contributors. These are a great way to get started with a project.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://firstcontributions.github.io" target="_blank" rel="noopener">
-					<img alt="First Contributions image link" title="First Contributions" src="img/projects/firstcontribution.jpg" />
+					<img alt="" title="First Contributions" src="img/projects/firstcontribution.jpg" />
 					<h3>First Contributions</h3>
 					<p>🚀✨ Make your first open source contribution in 5 minutes.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://ovio.org/issues" target="_blank" rel="noopener">
-					<img alt="Ovio image link" title="Ovio" src="img/projects/ovio.png" />
+					<img alt="" title="Ovio" src="img/projects/ovio.png" />
 					<h3>Ovio</h3>
 					<p>Boost your open-source contributions with Ovio's search and smart matching tools for developers.</p>
 				</a>
@@ -139,39 +139,39 @@
 			</header>
 			<div class="row">
 				<a class="col-sm-6 col-md-4 p-4" href="https://speakerinnen.org/" target="_blank" rel="noopener">
-					<img alt="Speakerinnen image link" title="Speakerinnen" src="img/projects/speakerinnen.jpg" />
+					<img alt="" title="Speakerinnen" src="img/projects/speakerinnen.jpg" />
 					<h3>Speakerinnen</h3>
 					<p>Register as speakerin & find speakerinnen!</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://en.wikipedia.org/wiki/Wikipedia:WikiProject_Women_in_Red" target="_blank" rel="noopener">
-					<img alt="WikiProject Women in Red image link" title="WikiProject Women in Red" src="img/projects/wikipedia-womeninred.png" />
+					<img alt="" title="WikiProject Women in Red" src="img/projects/wikipedia-womeninred.png" />
 					<h3>WikiProject Women in Red</h3>
 					<p>Increasing the representation of women on Wikipedia through biographies and articles of women’s achievements.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://chayn.co/" target="_blank" rel="noopener">
-					<img alt="Chayn image link" title="Chayn" src="img/projects/chayn.png" />
+					<img alt="" title="Chayn" src="img/projects/chayn.png" />
 					<h3>Chayn</h3>
 					<p>A volunteer network tackling gender based violence globally by creating intersectional survivor-led resources on the web.</p>
 				</a>
 			</div>
 			<div class="row">
 				<a class="col-sm-6 col-md-4 p-4" href="http://supernovaproject.org/" target="_blank" rel="noopener">
-					<img alt="Supernova Project image link" title="Supernova Project" src="img/projects/supernovaproject.svg" />
+					<img alt="" title="Supernova Project" src="img/projects/supernovaproject.svg" />
 					<h3>The Supernova Project</h3>
 					<p>Empowering LGBTQIA+ people around the world who are experiencing domestic abuse by providing a queer friendly platform of information and support.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://signdict.org/?locale=en" target="_blank" rel="noopener">
-					<img alt="SignDict image link" title="SignDict" src="img/projects/signdict.svg" />
+					<img alt="" title="SignDict" src="img/projects/signdict.svg" />
 					<h3>SignDict</h3>
 					<p>SignDict is an open dictionary for sign language. Everyone is invited to join in.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://wheelmap.org/" target="_blank" rel="noopener">
-					<img alt="wheelmap image link" title="wheelmap" src="img/projects/wheelmap.jpg" />
+					<img alt="" title="wheelmap" src="img/projects/wheelmap.jpg" />
 					<h3>Wheelmap</h3>
 					<p>The world's biggest crowdsourced and open database for ♿ wheelchair-accessible places.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://www.refugerestrooms.org/" target="_blank" rel="noopener">
-					<img alt="RefugeRestrooms project image link" title="RefugeRestrooms" src="img/projects/refugerestrooms.png" />
+					<img alt="" title="RefugeRestrooms" src="img/projects/refugerestrooms.png" />
 					<h3>RefugeRestrooms</h3>
 					<p>Helps transgender, intersex, and gender non-conforming individuals find safe restrooms worldwide. Crowdsourced, open, and inclusive.</p>
 				</a>
@@ -179,46 +179,46 @@
 			</div>
 			<div class="row">
 				<a class="col-sm-6 col-md-4 p-4" href="https://www.accessibility.cloud/" target="_blank" rel="noopener">
-					<img alt="accessibility cloud image link" title="accessibility cloud" src="img/projects/accessibilitycloud.png" />
+					<img alt="" title="accessibility cloud" src="img/projects/accessibilitycloud.png" />
 					<h3>accessibility.cloud</h3>
 					<p>Simplifies sharing and obtaining accessibility data in a standardized, future-proof, easy-to-use way.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://a11yproject.com" target="_blank" rel="noopener">
-					<img alt="a11y project image link" title="a11y project" src="img/projects/a11yproject.svg" />
+					<img alt="" title="a11y project" src="img/projects/a11yproject.svg" />
 					<h3>A11Y Project</h3>
 					<p>A community-driven effort to make web accessibility easier.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://voice.mozilla.org/" target="_blank" rel="noopener">
-					<img alt="common voice image link" title="common voice" src="img/projects/commonvoice.png" />
+					<img alt="" title="common voice" src="img/projects/commonvoice.png" />
 					<h3>Common Voice</h3>
 					<p>Mozilla's initiative to help teach machines how real people speak.</p>
 				</a>
 			</div>
 			<div class="row">
 				<a class="col-sm-6 col-md-4 p-4" href="https://chaoss.community/metrics/" target="_blank" rel="noopener">
-					<img alt="Chaoss Diversity and Inclusion Workgroup image link" title="Chaoss D&amp;I Workgroup" src="img/projects/chaoss.jpg" />
+					<img alt="" title="Chaoss D&amp;I Workgroup" src="img/projects/chaoss.jpg" />
 					<h3>CHAOSS D&amp;I Workgroup</h3>
 					<p>Collection of resources for projects to create a diversity and inclusion report.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://drnikki.github.io/open-demographics/" target="_blank" rel="noopener">
-					<img alt="Open Demographics image link" title="Open Demographics" src="img/projects/open-demographics.png" />
+					<img alt="" title="Open Demographics" src="img/projects/open-demographics.png" />
 					<h3>Open Demographics</h3>
 					<p>Open Demographics is a recommended set of questions that anyone can use to ask community members about their demographics.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://www.mediawiki.org/wiki/Wiki_Techstorm" target="_blank" rel="noopener">
-					<img alt="Wikimedia techstorm hackathon image link" src="img/projects/Techstorm-2019-logo-color.svg" />
+					<img alt="" src="img/projects/Techstorm-2019-logo-color.svg" />
 					<h3>Wikitechstorm</h3>
 					<p>Technical wikimedia hackaton designed initially for women*.</p>
 				</a>
 			</div>
 			<div class="row">
 				<a class="col-sm-6 col-md-4 p-4" href="https://meta.wikimedia.org/wiki/Gender_gap" target="_blank" rel="noopener">
-					<img alt="Mind the gap image link" src="img/projects/Mind_the_gap1.svg" />
+					<img alt="" src="img/projects/Mind_the_gap1.svg" />
 					<h3>Gender gap</h3>
 					<p>Hub for resources and information about Wikimedia's gender gaps.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://fr.wikipedia.org/wiki/Projet:Les_sans_pagEs" target="_blank" rel="noopener">
-					<img alt="les sans pages image link" src="img/projects/Les_sans_pagEs_drawing_Fhala.K.svg" />
+					<img alt="" src="img/projects/Les_sans_pagEs_drawing_Fhala.K.svg" />
 					<h3>les sans pagEs</h3>
 					<p>Francophone wikipedian project to reduce gender bias on wikimedia projects.</p>
 				</a>
@@ -228,7 +228,7 @@
 					<p>This cookbook is intended as a resource for organizers of conferences and events to support and encourage diversity and inclusion at those events.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://transdb.de/" target="_blank" rel="noopener">
-  					<img alt="TransDB logo" title="Trans*DB" src="img/projects/transdb.png" />
+  					<img alt="" title="Trans*DB" src="img/projects/transdb.png" />
 				    <h3>Trans*DB</h3>
 				    <p>Helps users in Germany find trans*-friendly doctors, therapists, and medical services for their transition.</p>
 				</a>
@@ -241,29 +241,29 @@
 			<p>Find a local space or meetup where you can work with like-minded people!</p>
 			<div class="row">
 				<a class="col-sm-6 col-md-4 p-4" href="https://opencollective.com/opensourcediversity/events" target="_blank" rel="noopener">
-					<img alt="Open Source Diversity Berlin Meetup image link" title="Open Source Diversity Berlin Meetup " src="img/opensourcediversity-icon-margin.svg" />
+					<img alt="" title="Open Source Diversity Berlin Meetup " src="img/opensourcediversity-icon-margin.svg" />
 					<h3>Open Source Diversity<br>Berlin</h3>
 					<p>Monthly meetup in Berlin for members of underrepresented groups who want to contribute to open source projects.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://diversifyingopensource.github.io" target="_blank" rel="noopener">
-					<img alt="Diversify Open Source Bangalore image link" title="Diversify Open Source Bangalore" src="img/projects/diversifyfoss.png" />
+					<img alt="" title="Diversify Open Source Bangalore" src="img/projects/diversifyfoss.png" />
 					<h3>Diversify Open Source<br>Bangalore</h3>
 					<p>We help, encourage and celebrate underrepresented people to contribute in open source projects and speak at conferences!</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="http://heartofcode.org" target="_blank" rel="noopener">
-					<img alt="Heart of Code image link" title="Heart of Code" src="img/projects/heartofcode.jpg" />
+					<img alt="" title="Heart of Code" src="img/projects/heartofcode.jpg" />
 					<h3>Heart of Code<br>Berlin</h3>
 					<p>Hurra, hurra, wir sind ein Hackerinnenaußenspace in Berlin!</p>
 				</a>
 			</div>
 			<div class="row">
 				<a class="col-sm-6 col-md-4 p-4" href="http://doubleunion.org" target="_blank" rel="noopener">
-					<img alt="Double Union San Francisco image link" title="Double Union San Francisco" src="img/projects/doubleunion.png" />
+					<img alt="" title="Double Union San Francisco" src="img/projects/doubleunion.png" />
 					<h3>Double Union<br>San Francisco</h3>
 					<p>Double Union is a hacker/maker space for women in San Francisco.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://openlabs.cc" target="_blank" rel="noopener">
-					<img alt="Open Labs Tirana image link" title="Open Labs Tirana" src="img/projects/openlabs.jpg" />
+					<img alt="" title="Open Labs Tirana" src="img/projects/openlabs.jpg" />
 					<h3>Open Labs<br>Tirana</h3>
 					<p>The first hackerspace in Albania dedicated to Free and Open Source Software, Privacy and the Commons.</p>
 				</a>
@@ -276,80 +276,80 @@
 			<p>Recurring programs for mentorship, funding or networking</p>
 			<div class="row">
 				<a class="col-sm-6 col-md-4 p-4" href="https://railsgirlssummerofcode.org" target="_blank" rel="noopener">
-					<img alt="RailsGirls Summer of Code image link" title="RailsGirls Summer of Code" src="img/projects/railsgirls.png" />
+					<img alt="" title="RailsGirls Summer of Code" src="img/projects/railsgirls.png" />
 					<h3>RailsGirls Summer of Code</h3>
 					<p>A global fellowship program aimed at bringing more diversity into Open Source. Successful applicants are paid a 3-month stipend to work on Open Source projects of their choice.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://www.outreachy.org" target="_blank" rel="noopener">
-					<img alt="Outreachy image link" title="Outreachy" src="img/projects/outreachy.png" />
+					<img alt="" title="Outreachy" src="img/projects/outreachy.png" />
 					<h3>Outreachy</h3>
 					<p>3-month internships for people traditionally underrepresented in tech. Interns work remotely with mentors from Free and Open Source Software communities.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://gssoc.girlscript.tech/" target="_blank" rel="noopener">
-					<img alt="GirlScript Summer of Code image link" title="GirlScript Summer of Code" src="img/projects/girlscriptsummerofcode.jpg" />
+					<img alt="" title="GirlScript Summer of Code" src="img/projects/girlscriptsummerofcode.jpg" />
 					<h3>GirlScript Summer of Code</h3>
 					<p>3 month long Open Source program during summers, with an aim to help beginners get started with Open Source Development while encouraging diversity.</p>
 				</a>
 			</div>
 			<div class="row">
 				<a class="col-sm-6 col-md-4 p-4" href="https://outspokenwomen.io" target="_blank" rel="noopener">
-					<img alt="Outspoken Women image link" title="Outspoken Women" src="img/projects/outspokenwomen.jpg" />
+					<img alt="" title="Outspoken Women" src="img/projects/outspokenwomen.jpg" />
 					<h3>Outspoken Women</h3>
 					<p>A resource for women and non-binary individuals in the open source tech industry by providing them with support, mentorship programs and financial scholarships to speak at events seeking underrepresented speakers and attendees.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://www.writespeakcode.com" target="_blank" rel="noopener">
-					<img alt="Write Speak Code image link" title="write/speak/code" src="img/projects/writespeakcode.jpg" />
+					<img alt="" title="write/speak/code" src="img/projects/writespeakcode.jpg" />
 					<h3>Write/Speak/Code</h3>
 					<p>Visibility and leadership for women & non-binary coders through thought leadership, conference speaking, open source & more.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://github.com/womenhackfornonprofits" target="_blank" rel="noopener">
-					<img alt="Women Hack for Non-profits image link" title="Women Hack for Non-Profits" src="img/projects/womenhackfornonprofits.jpg" />
+					<img alt="" title="Women Hack for Non-Profits" src="img/projects/womenhackfornonprofits.jpg" />
 					<h3>Women Hack for Non-Profits</h3>
 					<p>A community of women in tech building open source projects for non-profit organizations and individuals with a cause.</p>
 				</a>
 			</div>
 			<div class="row">
 				<a class="col-sm-6 col-md-4 p-4" href="https://openheroines.org" target="_blank" rel="noopener">
-					<img alt="open heroines image link" title="open heroines" src="img/projects/openheroines.jpg" />
+					<img alt="" title="open heroines" src="img/projects/openheroines.jpg" />
 					<h3>Open Heroines</h3>
 					<p>Voices of women working in open government, open data and civic tech.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://prototypefund.de" target="_blank" rel="noopener">
-					<img alt="Prototype Fund image link" title="Prototype Fund" src="img/projects/prototypefund.jpg" />
+					<img alt="" title="Prototype Fund" src="img/projects/prototypefund.jpg" />
 					<h3>Prototype Fund</h3>
 					<p>Der Prototype Fund unterstützt Softwareentwickler*innen, Hacker*innen und Kreative dabei, ihre Ideen vom Konzept bis zur ersten Demo zu entwickeln.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="http://joinfundclub.com" target="_blank" rel="noopener">
-					<img alt="Fund Club image link" title="Fund Club" src="img/projects/fundclub.jpg" />
+					<img alt="" title="Fund Club" src="img/projects/fundclub.jpg" />
 					<h3>Fund Club</h3>
 					<p>Pledge $100/month to fund tech projects by and for marginalized people.</p>
 				</a>
 			</div> 
 			<div class="row">
 				<a class="col-sm-6 col-md-4 p-4" href="https://www.redhat.com/en/about/women-in-open-source" target="_blank" rel="noopener">
-					<img alt="Women in Open Source Award image link" title="Women in Open Source Award" src="img/projects/womeninopensource.png" />
+					<img alt="" title="Women in Open Source Award" src="img/projects/womeninopensource.png" />
 					<h3>Women in Open Source Award</h3>
 					<p>We believe open source is the future of technology. It's time to recognize the contributions women are making and inspire a new generation to join the open source movement.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://www.globaldiversitycfpday.com" target="_blank" rel="noopener">
-					<img alt="Global Diversity CFP Day image link" title="Global Diversity CFP Day" src="img/projects/globaldiversitycfpday.jpg" />
+					<img alt="" title="Global Diversity CFP Day" src="img/projects/globaldiversitycfpday.jpg" />
 					<h3>Global Diversity CFP Day</h3>
 					<p>Workshops hosted around the globe encouraging and advising newbie speakers to put together your very first talk proposal.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://hacktoberfest.digitalocean.com/" target="_blank" rel="noopener">
-					<img alt="Hacktoberfest image link" title="Hacktoberfest" src="img/projects/hacktober.jpg" />
+					<img alt="" title="Hacktoberfest" src="img/projects/hacktober.jpg" />
 					<h3>Hacktoberfest</h3>
 					<p>Hacktoberfest is a month-long celebration of Open Source software which motivates Open Source contributors to boost up their contribution.</p>
 				</a>
 			</div>
 			<div class="row">
 				<a class="col-sm-6 col-md-4 p-4" href="https://www.fossjobs.net" target="_blank" rel="noopener">
-					<img alt="fossjobs.net image link" title="fossjobs.net" src="img/projects/fossjobs.svg" />
+					<img alt="" title="fossjobs.net" src="img/projects/fossjobs.svg" />
 					<h3>fossjobs.net</h3>
 					<p>Non-profit job portal from and for free & open source software enthusiasts. Only jobs at FOSS companies.</p>
 				</a>
 				<a class="col-sm-6 col-md-4 p-4" href="https://opensourcedesign.net/jobs/" target="_blank" rel="noopener">
-					<img alt="Open Source Design job board image link" title="Open Source Design job board" src="img/projects/opensourcedesign.svg" />
+					<img alt="" title="Open Source Design job board" src="img/projects/opensourcedesign.svg" />
 					<h3>Open Source Design job board</h3>
 					<p>Find design jobs in free & open source software projects or companies!</p>
 				</a>


### PR DESCRIPTION
Hi @jancborchardt,
I’ve updated the PR to ensure only decorative project card images use alt="", while keeping meaningful alt text for branding and functional icons.
Please let me know if anything else needs adjustment. Thanks!